### PR TITLE
Added Windows ARM64 support

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -2,7 +2,7 @@
 
 pushd winres
 
-go-winres simply -icon=icon.ico
+go-winres simply -icon=icon.ico -arch amd64,386,arm64
 
 popd
 
@@ -11,3 +11,6 @@ go build -o KakaoTalkAdBlock_amd64.exe -ldflags "-H windowsgui -s -w" .\cmd\main
 
 set GOARCH=386
 go build -o KakaoTalkAdBlock_i386.exe -ldflags "-H windowsgui -s -w" .\cmd\main.go
+
+set GOARCH=arm64
+go build -o KakaoTalkAdBlock_arm64.exe -ldflags "-H windowsgui -s -w" .\cmd\main.go


### PR DESCRIPTION
Tested on Snapdraon X Elite - X1E78100
![image](https://github.com/blurfx/KakaoTalkAdBlock/assets/6309929/6b64cf80-406c-41cd-a52b-f373d12cba17)

Compiled Binary:
[KakaoTalkAdBlock-ARM64-Support.zip](https://github.com/user-attachments/files/16112184/KakaoTalkAdBlock-ARM64-Support.zip)
