### PR TITLE
Qt6 기반 KakaoTalk Beta 지원

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -3,6 +3,7 @@ package internal
 import (
 	"bytes"
 	"context"
+	"kakaotalkadblock/internal/beta"
 	"kakaotalkadblock/internal/win/winapi"
 	"strings"
 	"sync"
@@ -43,9 +44,10 @@ func watch(ctx context.Context) {
 		if processId == uintptr(pe32.Th32ProcessID) {
 			lastFoundAt = time.Now().Unix()
 			className := winapi.GetClassName(handle)
+			parentHandle := winapi.GetParent(handle)
+			beta.TrackWindow(handle, className, parentHandle)
 			if className == "EVA_Window_Dblclk" || className == "EVA_Window" {
 				windowText := winapi.GetWindowText(handle)
-				parentHandle := winapi.GetParent(handle)
 
 				switch className {
 				case "EVA_Window_Dblclk":
@@ -82,7 +84,7 @@ func watch(ctx context.Context) {
 				for {
 					szExeFile = uint8ToStr(pe32.SzExeFile[:])
 
-					if strings.ToLower(szExeFile) == executable {
+					if strings.ToLower(szExeFile) == executable || beta.IsExecutable(szExeFile) {
 						winapi.EnumWindows(enumWindow, uintptr(pe32.Th32ProcessID))
 					}
 
@@ -101,6 +103,7 @@ func removeAd(ctx context.Context) {
 	ticker := time.NewTicker(sleepTime)
 
 	defer ticker.Stop()
+	defer beta.Restore()
 	for {
 		select {
 		case <-ctx.Done():
@@ -157,6 +160,7 @@ func removeAd(ctx context.Context) {
 					winapi.ShowWindow(wnd, 0)
 				}
 			}
+			beta.RemoveAds()
 			mutex.Unlock()
 		}
 	}

--- a/internal/beta/app_beta.go
+++ b/internal/beta/app_beta.go
@@ -1,0 +1,338 @@
+package beta
+
+import (
+	"kakaotalkadblock/internal/win/winapi"
+	"runtime"
+	"strings"
+	"sync"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	executable            = "kakaotalkui.exe"
+	qt6WindowClassPrefix  = "Qt6"
+	qtWindowClassSuffix   = "QWindowIcon"
+	chromeWidgetWindow    = "Chrome_WidgetWin_1"
+	chromeWidgetContainer = "Chrome_WidgetWin_0"
+	momentAdWindowTitle   = "MOMENT 광고"
+	chromeLegacyTitle     = "Chrome Legacy Window"
+	qt6AdContainerTitle   = "KakaoTalkUI"
+	clipExtraPadding      = 6
+	cornerDiameter        = 16
+	referenceDPI          = 144
+)
+
+type windowClip struct {
+	adHeight            int32
+	bottomInset         int32
+	dpi                 uint32
+	adWindow            windows.HWND
+	originalStyle       uintptr
+	styleChanged        bool
+	dwmMarginsSupported int8
+	appliedWidth        int32
+	appliedHeight       int32
+	appliedCropHeight   int32
+	appliedDpi          uint32
+	refreshTicks        uint8
+}
+
+var mutex = &sync.Mutex{}
+var mainWindowHandleMap = make(map[windows.HWND]struct{})
+var windowClipMap = make(map[windows.HWND]windowClip)
+var childWindowCollector []windows.HWND
+var childWindowCollectorCallback = syscall.NewCallback(func(handle windows.HWND, _ uintptr) uintptr {
+	childWindowCollector = append(childWindowCollector, handle)
+	return 1
+})
+
+func IsExecutable(name string) bool {
+	return strings.EqualFold(name, executable)
+}
+
+func TrackWindow(handle windows.HWND, className string, parentHandle windows.HWND) {
+	if !isQt6WindowClass(className) || parentHandle != 0 {
+		return
+	}
+	mutex.Lock()
+	mainWindowHandleMap[handle] = struct{}{}
+	mutex.Unlock()
+}
+
+func RemoveAds() {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	previousDpiContext := winapi.EnableThreadPerMonitorV2DpiAwareness()
+	defer winapi.RestoreThreadDpiAwareness(previousDpiContext)
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	for mainWindow := range mainWindowHandleMap {
+		if !winapi.IsWindow(mainWindow) {
+			delete(mainWindowHandleMap, mainWindow)
+			delete(windowClipMap, mainWindow)
+			continue
+		}
+		if !winapi.IsWindowVisible(mainWindow) {
+			continue
+		}
+		hideMomentAds(mainWindow)
+	}
+}
+
+func Restore() {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+	previousDpiContext := winapi.EnableThreadPerMonitorV2DpiAwareness()
+	defer winapi.RestoreThreadDpiAwareness(previousDpiContext)
+
+	mutex.Lock()
+	defer mutex.Unlock()
+	for mainWindow := range windowClipMap {
+		clearWindowClip(mainWindow)
+	}
+}
+
+func isQt6WindowClass(className string) bool {
+	return strings.HasPrefix(className, qt6WindowClassPrefix) && strings.HasSuffix(className, qtWindowClassSuffix)
+}
+
+func hideMomentAds(mainWindow windows.HWND) {
+	if clip, known := windowClipMap[mainWindow]; known {
+		if winapi.IsWindow(clip.adWindow) {
+			clipWindowForAd(mainWindow, clip.adWindow)
+			return
+		}
+	}
+
+	for _, handle := range getChildWindows(mainWindow) {
+		if winapi.GetClassName(handle) != chromeWidgetWindow || winapi.GetWindowText(handle) != momentAdWindowTitle {
+			continue
+		}
+		if !containsChromeLegacyWindow(handle) {
+			continue
+		}
+
+		chromeHost := winapi.GetParent(handle)
+		if winapi.GetClassName(chromeHost) != chromeWidgetContainer {
+			continue
+		}
+		adWindow := winapi.GetParent(chromeHost)
+		if !isQt6WindowClass(winapi.GetClassName(adWindow)) || winapi.GetWindowText(adWindow) != qt6AdContainerTitle {
+			continue
+		}
+
+		clipWindowForAd(mainWindow, adWindow)
+	}
+}
+
+func clipWindowForAd(mainWindow, adWindow windows.HWND) {
+	if !winapi.IsWindow(mainWindow) || !winapi.IsWindowVisible(mainWindow) || !winapi.IsWindow(adWindow) {
+		return
+	}
+	mainRect := new(winapi.Rect)
+	if !winapi.GetWindowRect(mainWindow, mainRect) {
+		return
+	}
+	mainWidth := mainRect.Right - mainRect.Left
+	mainHeight := mainRect.Bottom - mainRect.Top
+	if mainWidth < 1 || mainHeight < 1 {
+		return
+	}
+
+	currentDpi := winapi.GetDpiForWindow(mainWindow)
+	if currentDpi == 0 {
+		currentDpi = 96
+	}
+
+	clip, known := windowClipMap[mainWindow]
+	clip.adWindow = adWindow
+
+	adRect := new(winapi.Rect)
+	measured := false
+	if winapi.GetWindowRect(adWindow, adRect) {
+		if adHeight, bottomInset, ok := measureAd(mainRect, adRect); ok {
+			clip.adHeight = adHeight
+			clip.bottomInset = bottomInset
+			clip.dpi = currentDpi
+			measured = true
+		}
+	}
+
+	if !measured {
+		if !known || clip.adHeight < 1 || clip.dpi == 0 {
+			return
+		}
+		if clip.dpi != currentDpi {
+			clip.adHeight = scaleDpiValue(clip.adHeight, clip.dpi, currentDpi)
+			clip.bottomInset = scaleDpiValue(clip.bottomInset, clip.dpi, currentDpi)
+			clip.dpi = currentDpi
+		}
+	}
+
+	extraPadding := scaleDpiValue(clipExtraPadding, referenceDPI, currentDpi)
+	cropHeight := clip.adHeight + clip.bottomInset + extraPadding
+	visibleHeight := mainHeight - cropHeight
+	if visibleHeight < 1 {
+		return
+	}
+
+	if measured || winapi.IsWindowVisible(adWindow) {
+		collapseAdWindow(adWindow)
+	}
+	if !winapi.IsWindow(mainWindow) || !winapi.IsWindowVisible(mainWindow) {
+		return
+	}
+	geometryChanged := clip.appliedWidth != mainWidth ||
+		clip.appliedHeight != mainHeight ||
+		clip.appliedCropHeight != cropHeight ||
+		clip.appliedDpi != currentDpi
+	delayedRefresh := clip.refreshTicks > 0
+	frameChanged := false
+	useDwmMargins := clip.dwmMarginsSupported == 1
+	if clip.dwmMarginsSupported == 0 || (clip.dwmMarginsSupported == 1 && geometryChanged) {
+		useDwmMargins = winapi.SetDwmBorderMargins(mainWindow, cropHeight)
+		if useDwmMargins {
+			clip.dwmMarginsSupported = 1
+		} else {
+			clip.dwmMarginsSupported = -1
+		}
+	}
+	if useDwmMargins {
+		if clip.styleChanged {
+			currentStyle := winapi.GetWindowStyle(mainWindow)
+			restoredStyle := clip.originalStyle | currentStyle&winapi.WindowStateStyles
+			winapi.SetWindowStyle(mainWindow, restoredStyle)
+			winapi.SetDwmCornerPreference(mainWindow, false)
+			clip.styleChanged = false
+			frameChanged = true
+		}
+	} else {
+		currentStyle := winapi.GetWindowStyle(mainWindow)
+		if !clip.styleChanged {
+			clip.originalStyle = currentStyle &^ winapi.WindowStateStyles
+		}
+		targetStyle := (clip.originalStyle | currentStyle&winapi.WindowStateStyles) &^ winapi.DwmFrameWindowStyles
+		if winapi.IsZoomed(mainWindow) {
+			targetStyle |= clip.originalStyle & winapi.DwmFrameWindowStyles
+		}
+		if currentStyle != targetStyle && winapi.SetWindowStyle(mainWindow, targetStyle) {
+			frameChanged = true
+		}
+		if winapi.GetWindowStyle(mainWindow) == targetStyle {
+			styleChanged := targetStyle&winapi.DwmFrameWindowStyles != clip.originalStyle&winapi.DwmFrameWindowStyles
+			if clip.styleChanged != styleChanged {
+				winapi.SetDwmCornerPreference(mainWindow, styleChanged)
+				frameChanged = true
+			}
+			clip.styleChanged = styleChanged
+		}
+	}
+
+	if frameChanged || delayedRefresh || (clip.dwmMarginsSupported == 1 && geometryChanged) {
+		winapi.RefreshWindowFrame(mainWindow)
+	}
+	if geometryChanged || frameChanged {
+		if !winapi.IsWindow(mainWindow) || !winapi.IsWindowVisible(mainWindow) {
+			return
+		}
+		cornerSize := scaleDpiValue(cornerDiameter, referenceDPI, currentDpi)
+		region := winapi.CreateRoundRectRgn(0, 0, mainWidth, visibleHeight, cornerSize, cornerSize)
+		if region == 0 {
+			return
+		}
+		if !winapi.SetWindowRgn(mainWindow, region, true) {
+			winapi.DeleteObject(region)
+			return
+		}
+	}
+	if geometryChanged || frameChanged {
+		clip.refreshTicks = 2
+	}
+	if geometryChanged || frameChanged || delayedRefresh {
+		winapi.RedrawWindow(mainWindow)
+	}
+	if delayedRefresh {
+		clip.refreshTicks--
+	}
+	clip.appliedWidth = mainWidth
+	clip.appliedHeight = mainHeight
+	clip.appliedCropHeight = cropHeight
+	clip.appliedDpi = currentDpi
+	windowClipMap[mainWindow] = clip
+}
+
+func measureAd(mainRect, adRect *winapi.Rect) (adHeight, bottomInset int32, ok bool) {
+	if mainRect == nil || adRect == nil {
+		return 0, 0, false
+	}
+	mainWidth := mainRect.Right - mainRect.Left
+	mainHeight := mainRect.Bottom - mainRect.Top
+	adWidth := adRect.Right - adRect.Left
+	adHeight = adRect.Bottom - adRect.Top
+	bottomInset = mainRect.Bottom - adRect.Bottom
+	horizontalOverlap := min(mainRect.Right, adRect.Right) - max(mainRect.Left, adRect.Left)
+
+	if mainWidth < 1 || mainHeight < 1 || adWidth < 1 || adHeight < 1 {
+		return 0, 0, false
+	}
+	if adHeight >= mainHeight/2 || bottomInset < 0 || bottomInset >= mainHeight/3 {
+		return 0, 0, false
+	}
+	if horizontalOverlap < mainWidth/2 {
+		return 0, 0, false
+	}
+	return adHeight, bottomInset, true
+}
+
+func scaleDpiValue(value int32, fromDpi, toDpi uint32) int32 {
+	if value <= 0 || fromDpi == 0 || toDpi == 0 || fromDpi == toDpi {
+		return value
+	}
+	return int32((int64(value)*int64(toDpi) + int64(fromDpi)/2) / int64(fromDpi))
+}
+
+func collapseAdWindow(adWindow windows.HWND) {
+	if !winapi.IsWindow(adWindow) {
+		return
+	}
+	winapi.ShowWindow(adWindow, 0)
+	if !winapi.IsWindow(adWindow) {
+		return
+	}
+	flags := uint32(winapi.SwpNomove | winapi.SwpNozorder | winapi.SwpNoactivate)
+	winapi.SetWindowPos(adWindow, 0, 0, 0, 0, 0, flags)
+}
+
+func clearWindowClip(mainWindow windows.HWND) {
+	if !winapi.IsWindow(mainWindow) {
+		return
+	}
+	if clip, known := windowClipMap[mainWindow]; known && clip.styleChanged {
+		currentStyle := winapi.GetWindowStyle(mainWindow)
+		restoredStyle := clip.originalStyle | currentStyle&winapi.WindowStateStyles
+		winapi.SetWindowStyle(mainWindow, restoredStyle)
+	}
+	winapi.SetWindowRgn(mainWindow, 0, true)
+	winapi.SetDwmBorderMargins(mainWindow, 0)
+	winapi.SetDwmCornerPreference(mainWindow, false)
+	winapi.RefreshWindowFrame(mainWindow)
+	winapi.RedrawWindow(mainWindow)
+}
+
+func containsChromeLegacyWindow(handle windows.HWND) bool {
+	for _, child := range getChildWindows(handle) {
+		if winapi.GetWindowText(child) == chromeLegacyTitle {
+			return true
+		}
+	}
+	return false
+}
+
+func getChildWindows(parent windows.HWND) []windows.HWND {
+	childWindowCollector = childWindowCollector[:0]
+	winapi.EnumChildWindows(parent, childWindowCollectorCallback, 0)
+	return append([]windows.HWND(nil), childWindowCollector...)
+}

--- a/internal/win/winapi/constant.go
+++ b/internal/win/winapi/constant.go
@@ -6,5 +6,12 @@ const (
 
 	WmClose = 0x10
 
-	SwpNomove = 0x0002
+	SwpNosize       = 0x0001
+	SwpNomove       = 0x0002
+	SwpNozorder     = 0x0004
+	SwpNoactivate   = 0x0010
+	SwpFramechanged = 0x0020
+
+	DwmFrameWindowStyles = 0x00C40000
+	WindowStateStyles    = 0x21000000
 )

--- a/internal/win/winapi/dwmapi.go
+++ b/internal/win/winapi/dwmapi.go
@@ -1,0 +1,55 @@
+package winapi
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+type frameMargins struct {
+	Left   int32
+	Right  int32
+	Top    int32
+	Bottom int32
+}
+
+var dwmapi = windows.NewLazySystemDLL("dwmapi.dll")
+var dwmSetWindowAttribute = dwmapi.NewProc("DwmSetWindowAttribute")
+
+func SetDwmBorderMargins(hWnd windows.HWND, bottomCrop int32) bool {
+	const dwmwaBorderMargins = 40
+
+	margins := frameMargins{}
+	if bottomCrop > 0 {
+		margins.Left = 1
+		margins.Right = 1
+		margins.Top = 1
+		margins.Bottom = bottomCrop + 1
+	}
+
+	if err := dwmSetWindowAttribute.Find(); err != nil {
+		return false
+	}
+	hresult, _, _ := dwmSetWindowAttribute.Call(
+		uintptr(hWnd),
+		dwmwaBorderMargins,
+		uintptr(unsafe.Pointer(&margins)),
+		unsafe.Sizeof(margins),
+	)
+	return int32(hresult) >= 0
+}
+
+func SetDwmCornerPreference(hWnd windows.HWND, doNotRound bool) bool {
+	const dwmwaWindowCornerPreference = 33
+	preference := int32(0)
+	if doNotRound {
+		preference = 1
+	}
+	hresult, _, _ := dwmSetWindowAttribute.Call(
+		uintptr(hWnd),
+		dwmwaWindowCornerPreference,
+		uintptr(unsafe.Pointer(&preference)),
+		unsafe.Sizeof(preference),
+	)
+	return int32(hresult) >= 0
+}

--- a/internal/win/winapi/gdi32.go
+++ b/internal/win/winapi/gdi32.go
@@ -1,0 +1,17 @@
+package winapi
+
+import "golang.org/x/sys/windows"
+
+var gdi32 = windows.NewLazySystemDLL("gdi32.dll")
+var createRoundRectRgn = gdi32.NewProc("CreateRoundRectRgn")
+var deleteObject = gdi32.NewProc("DeleteObject")
+
+func CreateRoundRectRgn(left, top, right, bottom, ellipseWidth, ellipseHeight int32) uintptr {
+	r, _, _ := createRoundRectRgn.Call(uintptr(left), uintptr(top), uintptr(right), uintptr(bottom), uintptr(ellipseWidth), uintptr(ellipseHeight))
+	return r
+}
+
+func DeleteObject(object uintptr) bool {
+	r, _, _ := deleteObject.Call(object)
+	return r != 0
+}

--- a/internal/win/winapi/user32.go
+++ b/internal/win/winapi/user32.go
@@ -15,20 +15,31 @@ type Rect struct {
 }
 
 var (
-	user32                   = windows.NewLazySystemDLL("user32.dll")
-	getClassName             = user32.NewProc("GetClassNameW")
-	enumChildWindows         = user32.NewProc("EnumChildWindows")
-	enumWindows              = user32.NewProc("EnumWindows")
-	showWindow               = user32.NewProc("ShowWindow")
-	getParent                = user32.NewProc("GetParent")
-	setWindowPos             = user32.NewProc("SetWindowPos")
-	getWindowText            = user32.NewProc("GetWindowTextW")
-	getWindowRect            = user32.NewProc("GetWindowRect")
-	updateWindow             = user32.NewProc("UpdateWindow")
-	sendMessage              = user32.NewProc("SendMessageW")
-	getWindowThreadProcessId = user32.NewProc("GetWindowThreadProcessId")
-	moveWindow               = user32.NewProc("MoveWindow")
+	user32                       = windows.NewLazySystemDLL("user32.dll")
+	getClassName                 = user32.NewProc("GetClassNameW")
+	enumChildWindows             = user32.NewProc("EnumChildWindows")
+	enumWindows                  = user32.NewProc("EnumWindows")
+	showWindow                   = user32.NewProc("ShowWindow")
+	getParent                    = user32.NewProc("GetParent")
+	setWindowPos                 = user32.NewProc("SetWindowPos")
+	getWindowLongPtr             = user32.NewProc("GetWindowLongPtrW")
+	setWindowLongPtr             = user32.NewProc("SetWindowLongPtrW")
+	getWindowText                = user32.NewProc("GetWindowTextW")
+	getWindowRect                = user32.NewProc("GetWindowRect")
+	getDpiForWindow              = user32.NewProc("GetDpiForWindow")
+	isWindow                     = user32.NewProc("IsWindow")
+	isWindowVisible              = user32.NewProc("IsWindowVisible")
+	isZoomed                     = user32.NewProc("IsZoomed")
+	updateWindow                 = user32.NewProc("UpdateWindow")
+	sendMessage                  = user32.NewProc("SendMessageW")
+	getWindowThreadProcessId     = user32.NewProc("GetWindowThreadProcessId")
+	moveWindow                   = user32.NewProc("MoveWindow")
+	setWindowRgn                 = user32.NewProc("SetWindowRgn")
+	redrawWindow                 = user32.NewProc("RedrawWindow")
+	setThreadDpiAwarenessContext = user32.NewProc("SetThreadDpiAwarenessContext")
 )
+
+var windowStyleIndexArg = uintptr(^uint32(15))
 
 func GetClassName(hWnd windows.HWND) string {
 	buff := make([]uint16, 255)
@@ -71,6 +82,31 @@ func GetWindowRect(hWnd windows.HWND, lpRect *Rect) bool {
 	return r != 0
 }
 
+func GetWindowStyle(hWnd windows.HWND) uintptr {
+	style, _, _ := getWindowLongPtr.Call(uintptr(hWnd), windowStyleIndexArg)
+	return style
+}
+
+func SetWindowStyle(hWnd windows.HWND, style uintptr) bool {
+	setWindowLongPtr.Call(uintptr(hWnd), windowStyleIndexArg, style)
+	return GetWindowStyle(hWnd) == style
+}
+
+func IsWindow(hWnd windows.HWND) bool {
+	result, _, _ := isWindow.Call(uintptr(hWnd))
+	return result != 0
+}
+
+func IsWindowVisible(hWnd windows.HWND) bool {
+	result, _, _ := isWindowVisible.Call(uintptr(hWnd))
+	return result != 0
+}
+
+func IsZoomed(hWnd windows.HWND) bool {
+	result, _, _ := isZoomed.Call(uintptr(hWnd))
+	return result != 0
+}
+
 func UpdateWindow(hWnd windows.HWND) bool {
 	ret, _, _ := updateWindow.Call(uintptr(hWnd))
 	return ret != 0
@@ -100,4 +136,46 @@ func MoveWindow(hWnd windows.HWND, x, y, width, height int32, repaint bool) bool
 		uintptr(shouldRepaint),
 	)
 	return r != 0
+}
+
+func GetDpiForWindow(hWnd windows.HWND) uint32 {
+	if err := getDpiForWindow.Find(); err != nil {
+		return 0
+	}
+	dpi, _, _ := getDpiForWindow.Call(uintptr(hWnd))
+	return uint32(dpi)
+}
+
+func SetWindowRgn(hWnd windows.HWND, region uintptr, redraw bool) bool {
+	shouldRedraw := 0
+	if redraw {
+		shouldRedraw = 1
+	}
+	r, _, _ := setWindowRgn.Call(uintptr(hWnd), region, uintptr(shouldRedraw))
+	return r != 0
+}
+
+func RefreshWindowFrame(hWnd windows.HWND) bool {
+	flags := uint32(SwpNosize | SwpNomove | SwpNozorder | SwpNoactivate | SwpFramechanged)
+	return SetWindowPos(hWnd, 0, 0, 0, 0, 0, flags)
+}
+
+func RedrawWindow(hWnd windows.HWND) bool {
+	const flags = 0x0001 | 0x0080 | 0x0100 | 0x0400
+	result, _, _ := redrawWindow.Call(uintptr(hWnd), 0, 0, flags)
+	return result != 0
+}
+
+func EnableThreadPerMonitorV2DpiAwareness() uintptr {
+	if err := setThreadDpiAwarenessContext.Find(); err != nil {
+		return 0
+	}
+	previousContext, _, _ := setThreadDpiAwarenessContext.Call(^uintptr(3))
+	return previousContext
+}
+
+func RestoreThreadDpiAwareness(previousContext uintptr) {
+	if previousContext != 0 {
+		setThreadDpiAwarenessContext.Call(previousContext)
+	}
 }


### PR DESCRIPTION
Qt6 기반으로 리팩터링된 KakaoTalk Beta 버전은 기존 Win32 버전과 실행 파일명, 창 클래스 및 광고 영역 구조가 달라 기존 광고 차단 로직이 적용되지 않습니다.
https://github.com/blurfx/KakaoTalkAdBlock/issues/106

이 PR은 기존 Win32 기반 KakaoTalk 지원을 유지하면서, `KakaoTalkUI.exe`로 실행되는 Qt6 기반 Beta 버전을 별도의 모듈로 감지하고 광고 영역을 제거합니다.

## 새로운 차단 방식 설계

Qt6 Beta의 메인 창과 광고 영역은 다음과 같은 HWND 구조를 사용합니다.

```text
"카카오톡" Qt6*QWindowIcon
└─ "KakaoTalkUI" Qt6*QWindowIcon
   └─ "" Chrome_WidgetWin_0
      └─ "MOMENT 광고" Chrome_WidgetWin_1
         └─ "Chrome Legacy Window" Chrome_RenderWidgetHostHWND
```

광고 WebView `Chrome_WidgetWin_1`의 부모인 `"KakaoTalkUI"` Qt 광고 컨테이너를 광고 영역으로 식별합니다.

기존 win32 버전과 달리 Qt6 기반의 Beta에서는 광고가 다음 두 계층으로 분리되어 있습니다.
- Chromium WebView를 표시하는 네이티브 자식 HWND
- 광고 슬롯의 크기와 위치를 관리하는 Qt 내부 layout

창 트리에서 확인할 수 있는 Chrome_WidgetWin_*와 "KakaoTalkUI" HWND를 숨기거나 0×0으로 축소해도 Qt layout이 확보한 광고 슬롯 높이는 변경되지 않습니다.

```text
Qt 메인 layout
├─ 정상 콘텐츠
└─ 광고 슬롯             ← Qt 내부에서 높이를 계속 유지
   └─ KakaoTalkUI HWND
      └─ Chromium WebView
```

외부 AdBlock 프로세스에서 조작할 수 있는 것은 네이티브 HWND까지입니다. 일반 QWidget, layout item 또는 QML item은 반드시 개별 HWND를 가지는 것이 아니므로 Win32 API를 통한 열거 및 geometry 변경이 불가능합니다.
따라서 광고 HWND를 숨겨도 하단에 광고 높이만큼 빈 영역이 표시됩니다.

광고 높이만큼 최상위 HWND를 축소하는 방법도 검토했지만, Qt는 변경된 최상위 창 크기를 기준으로 내부 layout을 다시 계산하므로 창 전체 높이만 작아질 뿐 하단의 빈 광고 영역은 남습니다.
광고 컨테이너의 부모 HWND를 0×0으로 변경하는 것 역시 Qt layout item의 minimum size, size hint 또는 고정 높이를 변경하지 않으므로 동일한 문제가 발생합니다.

따라서 광고와 빈 슬롯을 모두 보이지 않게 만들기 위해 다음 방식을 사용합니다.

1. Qt 광고 컨테이너와 Chromium WebView 숨김
2. 광고 높이를 축소 전에 측정하고 저장
3. 최상위 HWND의 실제 크기는 유지
4. SetWindowRgn으로 광고 영역을 제외한 부분만 노출
5. 가능한 환경에서는 DWMWA_BORDER_MARGINS로 DWM 경계 보정
6. 지원되지 않는 환경에서는 창 프레임 스타일 제거로 하단 DWM 영역 억제


## 구현의 한계
이 방식은 Qt layout을 다시 실행하지 않으므로 광고 슬롯이 재생성되는 문제를 피할 수 있지만, 실제 최상위 HWND와 사용자에게 보이는 window region이 달라집니다. 그 결과 DWM과 운영체제가 최상위 창에 제공하는 일부 기능을 완전히 유지할 수 없어 다음과 같은 제약 사항이 발생합니다.

- 창 그림자가 사라짐
- 하단 border에 마우스 커서를 올려 창을 resize할 수 없음
- 창 최대화 시 하단에 기존 광고 높이만큼의 여백이 표시됨
- Windows 11 Snap Assist를 통한 창 배치가 불가능함(타이틀바 드래그를 이용한 창 배치 불가)

위 문제들은 `DWMWA_BORDER_MARGINS`를 사용할 수 없는 환경에서 하단의 투명한 DWM 영역을 제거하기 위해 `WS_CAPTION`과 `WS_THICKFRAME`을 제거하는 fallback에서 발생합니다.

해당 스타일을 유지하면 그림자, resize 및 Snap Assist는 복원되지만 기존 광고 영역만큼의 투명한 DWM 영역이 다시 나타납니다. 따라서 현재 구현에서는 광고 영역과 하단 투명 영역을 확실히 제거하는 동작을 우선합니다.


이러한 이슈들을 완전히 해결하려면 외부 HWND 조작이 아니라 KakaoTalk 프로세스 내부의 Qt 광고 widget 또는 QML item을 찾아 다음과 같이 실제 레이아웃에서 제거해야 합니다. 다만 이 방식은 DLL injection, Qt 함수 hooking 또는 프로세스 내부 패치가 필요해보입니다. 이는 본 프로젝트의 기존 코드베이스 방향과 일치하지 않다고 판단해 이번 PR에는 포함하지 않았습니다.

## 결과
테스트 환경은 다음과 같습니다.
- 운영체제: Windows 11 Home (26H1)
- 시스템 해상도: `2560×1440`
- 시스템 디스플레이 배율: `150%`
- KakaoTalk 내부 배율 설정: `100%`

<img width="504" height="760" alt="image" src="https://github.com/user-attachments/assets/20c54b77-5e28-43a3-aa82-5257eff88b1e" />


## 세부 구현

### 1. Qt6 Beta 감지 및 로직 분리

Qt6 관련 코드를 `internal/beta/app_beta.go`로 분리했습니다.

기존 프로세스 감시 코드에서 다음 항목을 Beta 모듈에 전달합니다.

- `KakaoTalkUI.exe` 프로세스 감지
- 최상위 Qt6 HWND 추적
- 광고 제거 주기 실행
- AdBlock 종료 시 원래 창 상태 복원

이를 통해 기존 `app.go`의 Win32 광고 차단 로직과 Qt6 전용 로직이 서로 섞이지 않도록 구성했습니다.

### 2. 광고 컨테이너 식별

다음 조건을 모두 만족하는 경우에만 Qt6 광고 컨테이너로 처리합니다.

- 실행 파일이 `KakaoTalkUI.exe`
- 최상위 창 클래스가 `Qt6*QWindowIcon`
- 광고 렌더러 제목이 `MOMENT 광고`
- 광고 렌더러 클래스가 `Chrome_WidgetWin_1`
- 부모 클래스가 `Chrome_WidgetWin_0`
- 상위 Qt 창 제목이 `KakaoTalkUI`
- 하위 트리에 `Chrome Legacy Window`가 존재

일반 채팅창이나 다른 Chromium 기반 하위 창이 광고로 오인되지 않도록 창 제목, 클래스, 부모 관계를 함께 검사합니다.

### 3. 광고 창 축소

식별된 `"KakaoTalkUI"` 광고 컨테이너에 다음 처리를 적용합니다.

- `ShowWindow(SW_HIDE)`
- `SetWindowPos(..., 0, 0, ...)`

WebView 렌더러뿐 아니라 광고 영역을 소유한 Qt 컨테이너 전체를 숨기고 `0×0`으로 축소합니다.

### 4. 메인 창 표시 영역 클리핑

광고 컨테이너를 숨겨도 Qt 내부 레이아웃은 기존 광고 슬롯 높이를 유지하므로 하단에 빈 영역이 남습니다.

Qt 프로세스 내부 레이아웃을 직접 변경하지 않고 다음 방식으로 표시 영역을 제한합니다.

1. 광고 컨테이너가 축소되기 전에 광고 높이와 하단 inset 측정
2. 측정값을 HWND별로 저장
3. 메인 창의 실제 크기는 유지
4. `SetWindowRgn`으로 표시 영역을 `전체 높이 - 광고 높이`로 제한
5. 광고 하단 border가 남지 않도록 DPI 보정된 추가 padding 적용
6. 창 크기 또는 DPI가 변경되면 region 재계산

### 5. DWM 프레임 처리

지원되는 Windows에서는 `DWMWA_BORDER_MARGINS`를 먼저 적용하여 실제 HWND 크기를 유지하면서 DWM 테두리 위치를 클리핑 경계 안쪽으로 이동시킵니다.

해당 속성이 지원되지 않거나 `DwmSetWindowAttribute`가 실패하면 다음 fallback을 사용합니다.

- `WS_CAPTION` 제거
- `WS_THICKFRAME` 제거
- DWM 둥근 모서리 비활성화
- `SetWindowRgn`으로 시각적·입력 영역 제한

### 6. DPI 대응

광고 높이와 클리핑 영역이 서로 다른 좌표계로 계산되지 않도록 처리했습니다.

- Win32 작업 스레드를 Per-Monitor V2 DPI awareness context로 전환
- `GetDpiForWindow`로 현재 창 DPI 확인
- 광고 높이, 하단 inset, 추가 padding 및 모서리 크기를 현재 DPI로 변환
- 해상도, 시스템 배율 또는 모니터가 변경되면 클리핑 영역 재계산
- 이전에 측정한 광고 높이는 DPI 변경 시 새 DPI 기준으로 변환